### PR TITLE
The columns are not removed when uninstalling the module

### DIFF
--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -45,7 +45,6 @@ class Uninstall implements UninstallInterface
             );
         }
 
-        // Remove column from quote_item table
         if ($setup->getConnection()->tableColumnExists(
             $setup->getTable('quote_item'),
             'is_gift'

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MageSuite\FreeGift\Setup;
+
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\UninstallInterface;
+
+class Uninstall implements UninstallInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function uninstall(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        if ($setup->getConnection()->tableColumnExists(
+            $setup->getTable('salesrule'),
+            \MageSuite\FreeGift\SalesRule\Action\AbstractGiftAction::RULE_DATA_KEY_SKU
+        )) {
+            $setup->getConnection()->dropColumn(
+                $setup->getTable('salesrule'),
+                \MageSuite\FreeGift\SalesRule\Action\AbstractGiftAction::RULE_DATA_KEY_SKU
+            );
+        }
+
+        if ($setup->getConnection()->tableColumnExists(
+            $setup->getTable('salesrule'),
+            \MageSuite\FreeGift\SalesRule\Action\AbstractGiftAction::RULE_DATA_KEY_SKU_DISCOUNTS
+        )) {
+            $setup->getConnection()->dropColumn(
+                $setup->getTable('salesrule'),
+                \MageSuite\FreeGift\SalesRule\Action\AbstractGiftAction::RULE_DATA_KEY_SKU_DISCOUNTS
+            );
+        }
+
+        if ($setup->getConnection()->tableColumnExists(
+            $setup->getTable('salesrule'),
+            \MageSuite\FreeGift\SalesRule\Action\AbstractGiftAction::RULE_DATA_KEY_SKU_QTY
+        )) {
+            $setup->getConnection()->dropColumn(
+                $setup->getTable('salesrule'),
+                \MageSuite\FreeGift\SalesRule\Action\AbstractGiftAction::RULE_DATA_KEY_SKU_QTY
+            );
+        }
+
+        // Remove column from quote_item table
+        if ($setup->getConnection()->tableColumnExists(
+            $setup->getTable('quote_item'),
+            'is_gift'
+        )) {
+            $setup->getConnection()->dropColumn(
+                $setup->getTable('quote_item'),
+                'is_gift'
+            );
+        }
+
+        $setup->endSetup();
+    }
+}


### PR DESCRIPTION
### Preconditions 
Tested on this versions:
    1. Magento 2.4.6-p1
    2. Magento 2.4.6-p2
    3. Module-version 1.2.5
### Description
Upon installation of the module, three columns—gift_skus, gift_skus_discount, and gift_sku_qty—are added to the "salesrule" table. Additionally, the column is_gifts is introduced in the "quote_item" table. However, during the uninstallation of the module, these columns are not automatically deleted from the database, which could potentially lead to issues.

### Steps to Reproduce
1: In the clean magento shop install the Magesuite-FreeGift module (composer require "creativestyle/magesuite-free-gift" ^1.0.0 
    and run the php bin/magento s:d:c && php bin/magento s:up)
2: After installing this module three column are added in ‘salesrule’  table the columns are gift_sku, gift_sku_discount, and 
    gift_sku_qty and  in ‘quote_item’ Table the column is_gift is added
3: After try to uninsatll the module from shop using the below command one by one:
    a-> php bin/magento module:disable MageSuite_FreeGift
    b->php bin/magento s:up
    c->php bin/magento module:enable MageSuite_FreeGift
    d->php bin/magento module:uninstall -r MageSuite_FreeGift
    e->php bin/magento s:up 
4: After uninstalling the module check the “salesrule” and ”quote_item” table and the column that generate when we install the 
    module are not removed from these table when we uninstall the module. In the screenshot below you can see that after 
    uninstalling the module the columns(gift_sku, gift_sku_discount, and gift_sku_) are still in ‘salesrule’ table   
![image](https://github.com/magesuite/free-gift/assets/124759248/2d79fd6d-173e-4f3c-8dc3-0402579311a3)

### Actual Result 
When uninstalling the module the column are not removed from database

### Expected Result 
When we uninstall the module the column should be removed from database

### Reason
In the module, only InstallSchema.php and UpgradeSchema.php files have been created. These files add the column when the module is installed, but there is no file to remove these columns when uninstalling the module
    



