### PR TITLE
Compatible without MSI modules

### DIFF
--- a/Model/ConfigProvider.php
+++ b/Model/ConfigProvider.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace MageSuite\FreeGift\Model;
+
+use Magento\Framework\Module\Manager;
+
+class ConfigProvider
+{
+    /**
+     * @var Manager
+     */
+    private $moduleManager;
+
+    /**
+     * ConfigProvider constructor.
+     *
+     * @param Manager $moduleManager
+     */
+    public function __construct(
+        Manager $moduleManager
+    ) {
+        $this->moduleManager = $moduleManager;
+    }
+
+    /**
+     * Check if magento inventory module is enabled
+     *
+     * @return bool
+     */
+    public function isMsiEnabled()
+    {
+        return $this->moduleManager->isEnabled('Magento_Inventory');
+    }
+}

--- a/Model/Factory/GetStockItemDataFactory.php
+++ b/Model/Factory/GetStockItemDataFactory.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace MageSuite\FreeGift\Model\Factory;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magento\InventorySalesApi\Model\GetStockItemDataInterface;
+
+class GetStockItemDataFactory implements ArgumentInterface
+{
+    protected $_objectManager;
+    protected $_instanceName;
+
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        $instanceName = GetStockItemDataInterface::class
+    ) {
+        $this->_objectManager = $objectManager;
+        $this->_instanceName = $instanceName;
+    }
+
+    public function create(array $data = [])
+    {
+        return $this->_objectManager->create($this->_instanceName, $data);
+    }
+}

--- a/Model/Factory/SalesChannelFactory.php
+++ b/Model/Factory/SalesChannelFactory.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace MageSuite\FreeGift\Model\Factory;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+
+class SalesChannelFactory implements ArgumentInterface
+{
+    protected $_objectManager;
+    protected $_instanceName;
+
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        $instanceName = SalesChannelInterface::class
+    ) {
+        $this->_objectManager = $objectManager;
+        $this->_instanceName = $instanceName;
+    }
+
+    public function create(array $data = [])
+    {
+        return $this->_objectManager->create($this->_instanceName, $data);
+    }
+}

--- a/Model/Factory/StockResolverFactory.php
+++ b/Model/Factory/StockResolverFactory.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace MageSuite\FreeGift\Model\Factory;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+
+class StockResolverFactory implements ArgumentInterface
+{
+    protected $_objectManager;
+    protected $_instanceName;
+
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        $instanceName = StockResolverInterface::class
+    ) {
+        $this->_objectManager = $objectManager;
+        $this->_instanceName = $instanceName;
+    }
+
+    public function create(array $data = [])
+    {
+        return $this->_objectManager->create($this->_instanceName, $data);
+    }
+}

--- a/Service/Cart.php
+++ b/Service/Cart.php
@@ -8,70 +8,87 @@ class Cart
      * @var \Magento\Framework\Data\Form\FormKey
      */
     protected $formKey;
+
     /**
      * @var \Magento\Checkout\Model\Cart
      */
     protected $cart;
+
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface
      */
     protected $productRepository;
+
     /**
      * @var \Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable
      */
     protected $configurableProduct;
+
     /**
      * @var \Magento\Framework\Serialize\Serializer\Json
      */
     protected $serializer;
+
     /**
      * @var \Magento\Framework\EntityManager\EventManager
      */
     protected $eventManager;
+
     /**
      * @var \Magento\CatalogInventory\Model\Quote\Item\QuantityValidator\QuoteItemQtyList
      */
     protected $quoteItemQtyList;
+
     /**
      * @var \Magento\Framework\App\RequestInterface
      */
     protected $request;
+
     /**
      * @var \Magento\Framework\App\RequestInterface
      */
     protected $response;
+
     /**
      * @var \Magento\Framework\DataObject\Factory
      */
     protected $dataObjectFactory;
+
     /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
     protected $storeManager;
+
     /**
      * @var \Magento\CatalogInventory\Api\StockStateInterface
      */
     protected $stockState;
+
     /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $scopeConfig;
+
     /**
      * @var \MageSuite\FreeGift\Model\Factory\GetStockItemDataFactory
      */
     protected $getStockItemDataFactory;
+
     /**
      * @var \MageSuite\FreeGift\Model\Factory\StockResolverFactory
      */
     protected $stockResolverFactory;
+
     /**
      * @var \MageSuite\FreeGift\Model\Factory\SalesChannelFactory
      */
     protected $salesChannelFactory;
+
     /**
      * @var \Magento\CatalogInventory\Api\StockRegistryInterface
      */
     protected $stockRegistry;
+
     /**
      * @var \MageSuite\FreeGift\Model\ConfigProvider
      */
@@ -116,7 +133,6 @@ class Cart
         \MageSuite\FreeGift\Model\Factory\SalesChannelFactory $salesChannelFactory,
         \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry,
         \MageSuite\FreeGift\Model\ConfigProvider $configProvider
-
     )
     {
         $this->formKey = $formKey;
@@ -318,27 +334,30 @@ class Cart
     protected function determineQtyWithoutMsi($requestedQty, $product)
     {
         $availableQuantity = 0.0;
+
         // Get stock item data
         $stockItem = $this->stockRegistry->getStockItemBySku($product->getSku());
-            if ($stockItem && $stockItem->getIsInStock()) {
-                $availableQuantity = $stockItem->getQty();
-            }
-        $qtyAlreadyAddedToCart = 0;
-            // Calculate quantity already added to cart
-            foreach ($this->cart->getQuote()->getAllItems() as $quoteItem) {
-                if ($quoteItem->isDeleted()) {
-                    continue;
-                }
-                if ($quoteItem->getProduct()->getId() != $product->getId()) {
-                    continue;
-                }
-                $qtyAlreadyAddedToCart += $quoteItem->getQty();
-                }
+        if ($stockItem && $stockItem->getIsInStock()) {
+            $availableQuantity = $stockItem->getQty();
+        }
 
-                $availableQuantity -= $qtyAlreadyAddedToCart;
-                if ($availableQuantity < 0) {
-                    return 0;
-                }
+        $qtyAlreadyAddedToCart = 0;
+
+        // Calculate quantity already added to cart
+        foreach ($this->cart->getQuote()->getAllItems() as $quoteItem) {
+            if ($quoteItem->isDeleted()) {
+                continue;
+            }
+            if ($quoteItem->getProduct()->getId() != $product->getId()) {
+                continue;
+            }
+            $qtyAlreadyAddedToCart += $quoteItem->getQty();
+        }
+
+        $availableQuantity -= $qtyAlreadyAddedToCart;
+        if ($availableQuantity < 0) {
+            return 0;
+        }
         return min($requestedQty, $availableQuantity);
     }
 


### PR DESCRIPTION
**Preconditions**
Tested on this versions:
1. Magento 2.4.6-p4
2. Magento 2.4.7
3. Module-version 1.3.0

**Description**
When the MSI module is disabled, and we set the cart price rule (add a gift) without a specific coupon code, we can't add a product to the cart when the subtotal is more than the rule price. If we set a rule with a specific coupon code, we are unable to apply that coupon code, and it gives an error (see screenshot 3)

**Steps to Reproduce**
1. Install a clean Magento shop with sampledata.
2. Installed the Magesuite-FreeGift module.
3. navigate to Marketing -> Cart Price Rules. Create a new cart rule, and within the Actions tab, set the options as depicted in the screenshot below(screeenshot 1)
![image](https://github.com/magesuite/free-gift/assets/124759630/7e92cf39-7a8a-48b5-a09e-a6c541da77a5)
4. Now, go to Catalog -> Products and create a product with a price greater than 100, as depicted in the screenshot below(Screenshot-2)
![image](https://github.com/magesuite/free-gift/assets/124759630/cdef1e7a-f0b8-4a8b-b7de-8a2ca9d8b6aa)
5. Now, go to the the frontend and add that product into the cart and apply that cart price rule.(screeenshot 3)
![image](https://github.com/magesuite/free-gift/assets/124759630/1135c8d1-5a08-4339-b663-ae3396798ad7)
6.observe.

**Actual Result**
The cart price rule should not be applied without the MSI module.

**Expected Result**
The cart price rule should be applied with or without the MSI module

**Reason**
This issue occurs when the MSI module is disabled. At that time, it is not compatible with the functionality in the module. They use the MSI class, and when that module is disabled, it should not run and creates an issue